### PR TITLE
Improve estimator efficiency

### DIFF
--- a/hill_estimator.ipynb
+++ b/hill_estimator.ipynb
@@ -28,7 +28,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from utils.functions import Hill_estimator"
+    "from utils.functions import hill_estimator"
    ]
   },
   {
@@ -458,7 +458,7 @@
     "print(\"[INFO] computing Hill Estimators...\")\n",
     "t0 = time()\n",
     "\n",
-    "kap_gains = Hill_estimator(df_sp_gains['Gains'].to_numpy())\n",
+    "kap_gains = hill_estimator(df_sp_gains['Gains'].to_numpy())\n",
     "\n",
     "print (\"        done in %0.3f minutes\" % ((time() - t0)/60))\n",
     "print (\"\")\n",
@@ -528,7 +528,7 @@
     "k_max = int(round(0.1*n_obs))\n",
     "k_min = 10\n",
     "\n",
-    "kap_loss = Hill_estimator(df_sp_loss['Losses'].to_numpy())\n",
+    "kap_loss = hill_estimator(df_sp_loss['Losses'].to_numpy())\n",
     "\n",
     "print (\"        done in %0.3f minutes\" % ((time() - t0)/60))\n",
     "print (\"\")\n",

--- a/utils/functions.py
+++ b/utils/functions.py
@@ -1,22 +1,21 @@
 import numpy as np
 
-def Hill_estimator(data):
+
+def hill_estimator(data):
     """
     Returns the Hill Estimators for some 1D data set.
-    """    
-    # sort data in such way that the smallest value is first and the largest value comes last:
-    Y = np.sort(data)
-    n = len(Y)
+    """
+    sorted_data = sorted(data, reverse=True)
 
-    Hill_est = np.zeros(n-1)
+    # Pre-compute all the logged data and cumulative log sums
+    log_sorted_data = np.log(sorted_data)  # log(Y_k)
+    cumulative_sum = np.cumsum(log_sorted_data)  # sum log(Y_j)
 
-    for k in range(0, n-1):    # k = 0,...,n-2
-        summ = 0
+    scales = np.arange(2, len(cumulative_sum) + 1)
+    scaled_log_sums = cumulative_sum[1:] / scales  # estimator starts at k = 2
 
-        for i in range(0,k+1):   # i = 0, ..., k
-            summ += np.log(Y[n-1-i]) - np.log(Y[n-2-k])
-        
-        Hill_est[k] = (1 / (k+1)) * summ      # add 1 to k because of Python syntax
-  
-    kappa = 1. / Hill_est
+    hill_est = scaled_log_sums - log_sorted_data[1:]
+
+    kappa = 1.0 / hill_est
+
     return kappa


### PR DESCRIPTION
Hey - I needed an implementation of the Hill estimator for work, Googled for it, and your repo came up. Thanks for the code!

I noticed the algorithm ran quite slow, and realized that there can be efficiency improvements:

The a lot of log values can be pre-computed and stored, and numpy opersations can be vectorized. Tested this on some data I had, timing went from ~1 minute to ~0.002 minutes.

Also made minor formatting changes / renamed some variables so the code is more readable.

Also minor bug fix: the original code was dividing by k - 1 instead of k compared to actual Hill estimator formula. (There is some minor error with the formula in the READ.me but I don't know how to edit the latex there, so leaving it as-is.)
